### PR TITLE
fix: removed circular dependency on release flow

### DIFF
--- a/.github/workflows/publish-azure-extension.yml
+++ b/.github/workflows/publish-azure-extension.yml
@@ -8,10 +8,6 @@ on:
         type: string
 
 jobs:
-  call-release-workflow:
-    name: call release workflow
-    uses: ./.github/workflows/release.yml
-
   run_and_publish_tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The release.yaml triggers the publish-azure-extension.yaml. Removed the circular dependency