### PR TITLE
fix: env variable has a different name in package_extension_and_publish_build_artifacts

### DIFF
--- a/.github/workflows/publish-azure-extension.yml
+++ b/.github/workflows/publish-azure-extension.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_and_publish_tests
     env:
-      RELEASE_VERSION: ${{ inputs.release_version_output }}
+      RELEASE_VERSION: ${{ inputs.release_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
pipeline is failing due to different naming schemes of the env variable