### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -6,6 +6,9 @@ on:
       - main
       - docs/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,10 +19,12 @@ jobs:
 
     steps:
       - name: Checkout Github Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -42,14 +47,14 @@ jobs:
         run: echo "COMMIT_HASH=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64
@@ -59,4 +64,6 @@ jobs:
 
   call-github-action:
     needs: build
+    permissions:
+      contents: read
     uses: ./.github/workflows/integration_testing_github_action.yml

--- a/.github/workflows/integration_testing_github_action.yml
+++ b/.github/workflows/integration_testing_github_action.yml
@@ -8,9 +8,13 @@ on:
 jobs:
   analyze-sbom:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Test Action Default License
         uses: ./
         id: analyze-sbom-default-license
@@ -26,7 +30,7 @@ jobs:
           LICENSE_POLICY_PATH: "/github/workspace/tests/files/mw_license_policy.json"
           IGNORE_PKG_TYPES: ""
       - name: Upload SBOM evaluation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: evaluated_sbom
           path: ${{ github.workspace }}/evaluated_sbom.csv

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,22 +6,26 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
 
     - name: install hadolint
       run: |
         sudo wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
         sudo chmod +x /bin/hadolint
 
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:
         extra_args: "--show-diff-on-failure --color=always --from-ref origin/main --to-ref HEAD"

--- a/.github/workflows/public_testing_github_actions.yaml
+++ b/.github/workflows/public_testing_github_actions.yaml
@@ -8,12 +8,16 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -29,7 +33,7 @@ jobs:
       - name: Unit tests license-policy-check
         run: cd tools/license-policy-check/testing && pytest test_check_usage_policy.py -q && cd ../../..
 
-      - uses: MaibornWolff/purl-patrol@main
+      - uses: MaibornWolff/purl-patrol@101183a0a395da5bad182c3f4722925750b06ee4 # main
         with:
           SBOM_PATH: ${{env.SBOM_PATH}}
           BREAK_ENABLED: false

--- a/.github/workflows/publish-azure-extension.yml
+++ b/.github/workflows/publish-azure-extension.yml
@@ -10,11 +10,15 @@ on:
 jobs:
   run_and_publish_tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/Jod'
 
@@ -30,7 +34,7 @@ jobs:
         working-directory: ./extensions/azure-devops/task/PurlPatrolV1
 
       - name: Publish test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results
           path: './extensions/azure-devops/task/PurlPatrolV1/test-result.txt'
@@ -39,16 +43,20 @@ jobs:
   package_extension_and_publish_build_artifacts:
     runs-on: ubuntu-latest
     needs: run_and_publish_tests
+    permissions:
+      contents: read
     env:
       RELEASE_VERSION: ${{ inputs.release_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: update docker image tag
-        run: sed -i -e 's/latest/${{ env.RELEASE_VERSION }}/' ./extensions/azure-devops/task/PurlPatrolV1/src/index.ts
+        run: sed -i -e "s/latest/$RELEASE_VERSION/" ./extensions/azure-devops/task/PurlPatrolV1/src/index.ts
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/Jod'
       - name: Install dependencies
@@ -66,14 +74,14 @@ jobs:
         working-directory: ./extensions/azure-devops
         run: |
           tfx extension create --root ./ --manifest-globs vss-extension.json \
-          --override '{"version": "${{ env.RELEASE_VERSION }}"}' \
+          --override "{\"version\": \"$RELEASE_VERSION\"}" \
           --share-with PURL-patrol
 
       - name: Copy Files to Artifact Staging Directory
         run: cp ./extensions/azure-devops/*.vsix $GITHUB_WORKSPACE
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: packaged-extension
           path: "${{ github.workspace }}/*.vsix"
@@ -82,10 +90,12 @@ jobs:
   download_build_artifacts_and_publish_the_extension:
     runs-on: ubuntu-latest
     needs: package_extension_and_publish_build_artifacts
+    permissions:
+      contents: read
     env:
       PAT: ${{ secrets.AZURE_PAT }}
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/Jod'
 
@@ -93,12 +103,12 @@ jobs:
         run: npm install -g tfx-cli
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: packaged-extension
 
       - name: Login to Azure cli
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true
@@ -113,9 +123,11 @@ jobs:
   test_the_published_extension:
       runs-on: ubuntu-latest
       needs: download_build_artifacts_and_publish_the_extension
+      permissions:
+        contents: read
       steps:
         - name: Login to Azure cli
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
             allow-no-subscriptions: true
@@ -125,7 +137,7 @@ jobs:
            TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" -o tsv)
            echo "ACCESS_TOKEN=${TOKEN}" >> $GITHUB_ENV
 
-        - uses: Azure/pipelines@v1
+        - uses: Azure/pipelines@354dddefceb0b503a61338ca81e4091eae3bc84f # v1
           with:
             azure-devops-project-url: 'https://dev.azure.com/PURL-patrol/purl-patrol'
             azure-pipeline-name: 'purl-patrol-pipeline-test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # test:
 
@@ -11,16 +14,19 @@ jobs:
     # needs: [test]
     runs-on: ubuntu-latest
     name: semantic-release
+    permissions:
+      contents: write
     outputs:
       RELEASE_TAG: ${{ steps.release.outputs.RELEASE_TAG }}
       RELEASE_VERSION: ${{ steps.release.outputs.RELEASE_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "lts/*"
       - name: Install dependencies
@@ -41,20 +47,21 @@ jobs:
     needs: [semantic-release]
     steps:
       - name: Checkout Github Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.repository }}
           ref: ${{ needs.semantic-release.outputs.RELEASE_TAG }}
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64
@@ -64,23 +71,29 @@ jobs:
             ghcr.io/maibornwolff/purl-patrol:${{ needs.semantic-release.outputs.RELEASE_VERSION }}
 
       - name: Create SBOM with Docker Scout
+        env:
+          RELEASE_VERSION: ${{ needs.semantic-release.outputs.RELEASE_VERSION }}
         run: |
           curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
           sh install-scout.sh
-          docker scout sbom ghcr.io/maibornwolff/purl-patrol:${{ needs.semantic-release.outputs.RELEASE_VERSION }} --format cyclonedx -o sbom.cdx.json
+          docker scout sbom ghcr.io/maibornwolff/purl-patrol:$RELEASE_VERSION --format cyclonedx -o sbom.cdx.json
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sbom
           path: sbom.cdx.json
 
   call-github-action:
     needs: delivery
+    permissions:
+      contents: read
     uses: ./.github/workflows/public_testing_github_actions.yaml
 
   calling-publish-azure-extension-workflow:
     needs: delivery
+    permissions:
+      contents: read
     uses: ./.github/workflows/publish-azure-extension.yml
     with:
       release_version: ${{needs.semantic-release.outputs.RELEASE_VERISON}}

--- a/.github/workflows/test-sbom-creation.yml
+++ b/.github/workflows/test-sbom-creation.yml
@@ -5,20 +5,24 @@ on:
 jobs:
   testing:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout Github Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.repository }}
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: oras-project/setup-oras@v1
+      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
 
       - name: Create SBOM with Docker Scout
         run: |
@@ -28,7 +32,7 @@ jobs:
           docker scout sbom ghcr.io/maibornwolff/purl-patrol:$RELEASE --format cyclonedx -o sbom.cdx.json
           oras attach ghcr.io/maibornwolff/purl-patrol:$RELEASE sbom.cdx.json --artifact-type sbom/cyclonedx
 
-      - uses: MaibornWolff/purl-patrol@main
+      - uses: MaibornWolff/purl-patrol@101183a0a395da5bad182c3f4722925750b06ee4 # main
         with:
           SBOM_PATH: sbom.cdx.json
           BREAK_ENABLED: 'false'


### PR DESCRIPTION
- Pin all action references to SHA hashes
- Add persist-credentials: false to all checkout steps
- Add least-privilege permissions blocks to all workflows/jobs
- Fix template injection by using shell env vars in run blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by adding explicit permission configurations across workflows, pinning GitHub Actions to specific commit versions for improved reproducibility, and disabling credential persistence where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->